### PR TITLE
Update Class.md

### DIFF
--- a/source/iOS/ObjC-Basic/Class.md
+++ b/source/iOS/ObjC-Basic/Class.md
@@ -86,7 +86,7 @@ OC 中的方法只要声明在 @interface里，就可以认为都是公有的。
 和使用 Category 相比，使用 Extension 有以下两个好处：
 
 1. Extension 声明的方法必须在类的主 @implementation 区间内实现，可以避免使用有名 Category 带来的多个不必要的 implementation 段。
-2. 如果 Extension 中声明的方法没有实现，编译器会给出 Warning，使用 Category 则不会。
+2. Extension 可以添加成员变量。
 
 
 ## 类变量


### PR DESCRIPTION
”如果 Extension 中声明的方法没有实现，编译器会给出 Warning，使用 Category 则不会。“

删除理由：该信息过于古老。

我已经删除了 4.x 版本 Xcode，所以无法进行测试。但是根据一份 2007 年的文件显示，clang 在设计时就已经支持 **警告 category 中未实现的方法**；所以，随着 Xcode 4 的推出，并在后续版本中默认设置 clang 为前端。该功能已经在多年前的 Xcode 中就已经实现。

http://llvm.org/viewvc/llvm-project/cfe/trunk/test/Sema/method-undef-category-warn-1.m?view=markup&pathrev=42531


“Extension 可以添加成员变量。”
同样的，大概在3、4年前，ObjC 就已经支持了在 Extension 中添加成员变量了。这是 extension 和 category 的一个非常重大的区别。