### PR TITLE
修改错误的描述

### DIFF
--- a/source/iOS/ObjC-Basic/Class.md
+++ b/source/iOS/ObjC-Basic/Class.md
@@ -147,7 +147,7 @@ OC 中的方法只要声明在 @interface里，就可以认为都是公有的。
 @property (getter=isFinished) BOOL finished;
 ```
 
-这种情况下，编译器也会只生成 getter，而不生成 setter。
+这种情况下，编译器生成的 getter 方法名为 `isFinished`，而不是 `finished`。
 
 ### @synthesize 和 @dynamic
 


### PR DESCRIPTION
自定义 accessor 的名字时，编译器依然会生成 getter 方法，但是 getter 方法名会变为自定义的名字，而不是和属性相同的名字。